### PR TITLE
Add header link to GitHub repository

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,9 @@ title: DfE Architecture
 
 permalink: pretty
 
+header_links:
+  GitHub: https://github.com/DFE-Digital/architecture
+
 defaults:
   -
     scope:


### PR DESCRIPTION
Adds GitHub repository link to header.

<img width="858" alt="Screenshot 2020-09-25 at 11 06 52" src="https://user-images.githubusercontent.com/4628936/94254880-4ed6f200-ff1f-11ea-8f7a-47d58ed13fd9.png">
