### PR TITLE
Add accessibility statement page with footer link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,9 @@ title: DfE Architecture
 
 permalink: pretty
 
+footer_links:
+  Accessibility: https://dfe-digital.github.io/architecture/accessibility
+
 defaults:
   -
     scope:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,16 @@
 <footer class="footer">
   <div class="footer__licence">
+    {% if site.footer_links %}
+    <ul>
+      {% for link in site.footer_links %}
+        <li>
+          <a href="{{ link[1] }}">
+            {{ link[0] }}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  {% endif %}
     <a class="footer__licence-logo" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a>
     <p class="footer__licence-description">All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
   </div>

--- a/_sass/modules/_footer.scss
+++ b/_sass/modules/_footer.scss
@@ -12,7 +12,7 @@
  *     <a class="footer__licence-logo" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a>
  *     <p class="footer__licence-description">All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
  *   </div>
- * 
+ *
  *   <div class="footer__copyright">
  *     <a class="footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
  *   </div>
@@ -33,7 +33,7 @@ $footer-text: $footer-link;
   border-top: 1px solid $footer-border-top;
   background: $footer-background;
   color: $footer-text;
-  
+
   @include media(tablet) {
     padding: $gutter;
     display: flex;
@@ -79,6 +79,12 @@ $footer-text: $footer-link;
   }
 }
 
+.footer__licence ul {
+  @include core-16;
+  list-style: none;
+  padding: 0;
+}
+
 .footer__licence-description {
   @include core-16;
   margin: 0 0 1em;
@@ -93,7 +99,7 @@ $footer-text: $footer-link;
 .footer__copyright-logo {
   display: block;
   white-space: nowrap;
-  
+
   padding: 115px 0 0 0;
   min-width: 125px;
 
@@ -101,13 +107,13 @@ $footer-text: $footer-link;
   background-size: 125px 102px;
   background-repeat: no-repeat;
   background-position: 50% 0%;
-  
+
   text-align: center;
   text-decoration: none;
 
   @include device-pixel-ratio() {
     background-image: file-url("govuk-crest-2x.png");
-  }    
+  }
 }
 
 .flexbox, .flexboxtweener {

--- a/accessibility.md
+++ b/accessibility.md
@@ -1,0 +1,81 @@
+# Accessibility
+
+## Accessibility statement for DfE Architecture
+
+This accessibility statement applies to DfE Architecture at [https://dfe-digital.github.io/architecture/](https://dfe-digital.github.io/architecture/).
+
+This website is run by the architecture community at the Department for Education (DfE). We want as many people as possible to be able to use this website. For example, that means you should be able to:
+
++ change colours, contrast levels and fonts
++ zoom in up to 300% without problems
++ navigate most of the website using just a keyboard
++ navigate most of the website using speech recognition software
++ listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+
+We’ve also made the website text as simple as possible to understand.
+
+[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
+
+### How accessible this website is
+
+Currently the website should be fully accessible and there are no linked images or documents on the pages which could cause accessibility issues.
+
+### What to do if you cannot access parts of this website
+
+If you need information on this website in a different format like accessible PDF, large print, easy read, audio recording or braille, contact [architecture.services@education.gov.uk](mailto:architecture.services@education.gov.uk) with details of your request.
+
+We’ll aim to reply within 3 working days.
+
+### Reporting accessibility problems with this website
+
+We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email [architecture.services@education.gov.uk](mailto:architecture.services@education.gov.uk).
+
+### Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
+
+## Technical information about this website’s accessibility
+
+DfE is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+
+## Compliance status
+
+This website is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard, due to the non-compliances listed below.
+
+### Non-accessible content
+
+The following pages contain PNG images which are not fully explained in the text:
+
+- [https://dfe-digital.github.io/architecture/standards/common-definitions/#common-definitions](https://dfe-digital.github.io/architecture/standards/common-definitions/#common-definitions)
+- [https://dfe-digital.github.io/architecture/common-components/#common-components](https://dfe-digital.github.io/architecture/common-components/#common-components)
+- [https://dfe-digital.github.io/architecture/governance/governance-and-design/#governance-and-design](https://dfe-digital.github.io/architecture/governance/governance-and-design/#governance-and-design)
+- [https://dfe-digital.github.io/architecture/capability/architecture-capability-framework/#architecture-capability-framework](https://dfe-digital.github.io/architecture/capability/architecture-capability-framework/#architecture-capability-framework)
+
+These issues partially fail or fail [WCAG 2.1 success criterion 1.4.5 Images of Text.](https://www.w3.org/TR/2008/WD-UNDERSTANDING-WCAG20-20081103/visual-audio-contrast-text-presentation.html)
+
+There are also parts of this documentation that are not accessible because of [issues caused by the Technical Documentation Template.](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation)
+
+## How we tested this website
+
+We last tested this website for accessibility issues in September 2020.
+
+We used manual and automated tests to look for issues such as:
+
+- lack of keyboard accessibility
+- link text that’s not descriptive
+- non-unique or non-hierarchical headings
+- italics, bold or block capital formatting
+- inaccessible formatting in general
+- inaccessible language
+- inaccessible diagrams or images
+- lack of colour contrast for text, important graphics and controls
+- images not having meaningful alt text
+- problems when using assistive technologies such as screen readers and screen magnifiers
+
+## What we’re doing to improve accessibility
+
+When we publish new content, we’ll make sure our use of images meets accessibility standards.
+
+We plan to fix the issues with the images by the end of 2020.
+
+This statement was prepared on 24 September 2020. It was last updated on 24 September 2020.


### PR DESCRIPTION
Adds accessibility statement page in line with [accessibility regulation](https://accessibility.campaign.gov.uk/).

Outlines pages which have non-accessible content (images).