### PR TITLE
Lead / role of architects

### DIFF
--- a/capability/architecture-capability-framework.md
+++ b/capability/architecture-capability-framework.md
@@ -1,6 +1,6 @@
 ---
-category: Architecture Capability
-expires: 2020-12-01
+category: capability
+expires: 2022-03-31
 ---
 
 # Architecture Capability Framework
@@ -14,6 +14,12 @@ It describes the pathways into architecture and how to develop an architecture c
 
 It builds on the [GOV.UK DDaT Capability Framework](https://www.gov.uk/government/collections/digital-data-and-technology-profession-capability-framework), extending the various skills, levels and mastery for the context of DfE.
 
+## The role of an architect through the delivery lifecycle
+| | Planning | Discovery | Alpha | Beta (private/public) | Live |
+| ----| ---- | ---- | ---- | ---- | ---- |
+| **Questions to answer**| What is the problem space? Is there a problem to solve? | What is the problem? How big is it? Can we solve it? | What are our risky assumptions? How can we release value early? | What should we build first and is it adding value? |How can we continually add value to the service? |
+| **Things an architect might focus on** | Problem framing, stakeholder mapping, input to business case | Problem statement, goals and drivers, conceptual views, business/technical capability mapping, early option thinking | Solution prototyping, capability / service / application views, data architecture, design assumptions and constraints, options considered / tested | High > low level design (applications, data, integration, hosting, security), infrastructure / network topology, disaster recovery, logging, auditing, error handling, managing the service and support, architecture / design decisions | Continual improvement, relationships with suppliers, learning/future recommendations |
+
 ## The skills and experience you'll need
 In DfE, we have a mix of enterprise, solution, technical and data architects. We also have tech leads and a Head of Profession - there are lots of different roles and teams that do architecture in one way or another, across a number of business areas.
 
@@ -25,7 +31,7 @@ Enterprise Architects work across the DfE at a strategic level to translate busi
 
 Their responsibilities include:
 
-- establishing the architectural principles, policies and standards
+- establishing the architectural principles, patterns and standards
 - assuring technology decisions are aligned to architecture and technical strategies
 - ownership of architecture strategy and roadmaps, including ‘as-is’ and ‘to-be’ transitional states
 - understanding DfE's ecosystem and its inter-dependencies
@@ -58,14 +64,14 @@ We also have an architecture practice and community manager and some professiona
 Here are some examples of the expected responsibilities at different levels:
 
 
-| | G6 Enterprise Architect | G7 Solution Architect | SEO Technical Architect
+| | G6 Lead Architect | G7 Senior Architect | SEO Architect
 - | - | - | -
-__Delivery__ | One or more portfolio(s) or business domain(s) | A group of projects aligned to one or more portfolio(s) or business domain(s) | A group of projects aligned to one or more portfolio(s) or business domain(s)
-__Assurance__ | Review of business cases, establish controls, ARB submissions, technical service assessments, design assurance of major/critical programmes | Establish controls, ARB / TDA submissions, technical assessment, design assurance of projects and programmes | Establish controls, ARB / TDA submissions, technical assessment, design assurance of projects and programmes
+__Delivery__ | Across one or more portfolios or business domains | Across a programme or group of projects, aligned to a portfolio or domain | Across one or a small group of projects, aligned to a portfolio or domain
+__Assurance__ | Review of business cases, establish in-line assurance mechanisms, reviewing submissions for assurance, technical service assessment, design assurance of major/critical programmes | Establish/support assurance mechanisms, assurance submissions, technical service assessment, design assurance of projects and programmes | Participate in assurance mechanisms, technical service assessment, design assurance of projects
 __Strategies__ | Own one or more technology strategies and roadmaps | + One or more technology strategies and roadmaps |
 __Thought leadership__ | Write thematic papers to influence, lead community discussions | + Write thematic papers to influence, lead community discussions |
-__Line management__ | Team plans and management, workforce management | + Management of colleagues |
-__Corporate__ | Budget delegation, corporate work (embedded), mentoring, recruitment, xGovernment collaboration | + Corporate work (actively involved), mentoring, recruitment, xGovernment collaboration | + Recruitment, xGovernment collaboration
+__Line management__ | Team plans and management, workforce management | + Management and coaching of colleagues |
+__Corporate__ | Budget delegation, leading cross-cutting work, mentoring, recruitment, xGovernment collaboration | + Cross-cutting work (actively involved), mentoring, recruitment, xGovernment collaboration | + Recruitment, xGovernment collaboration
 
 (+ indicates a stretch goal)
 

--- a/profession/architecture-profession.md
+++ b/profession/architecture-profession.md
@@ -40,21 +40,21 @@ They:
 
 Use the table below to find out who your lead architect is. Or contact the [architecture profession](mailto:architecture.profession@education.gov.uk) if you're not sure.
 
-| **Business area** | **Portfolio/domain** | **Lead architect/s** |
+| Business area | Portfolio/domain | Lead architect/s |
 | - | - | - |
-**Digital and Technology** | Teaching Workforce | Andy Emley |
-| | Setting Leadership | tbc |
-| | Vulnerable Families and Children | Craig Jackson |
-| | School Business Professionals | Stewart Bailey-Smith, Atif Mir
-| | Internal Services/Digital Efficiencies | tbc |
-| | Platforms and Infrastructure | John Carter |
-| | Cyber Security | Pete Dingwall
-| | End User Services | John Phillips |
-| | Operational Services | Mario Gledhill |
-| | Digital Strategy | Ant McCrea |
-**Outside Digital and Technology** | CEDD (+ ESFA) | Jemma Sheargold |
-| | Funding Services | John Harris |
-| | Data | Mick Rothwell |
+**Digital and Technology** | Teacher services | Andy Emley |
+| | Setting leadership | tbc |
+| | Vulnerable families and children | Craig Jackson, tbc |
+| | School business professionals | Stewart Bailey-Smith, Atif Mir
+| | Internal services / digital efficiencies | tbc |
+| | Platforms and infrastructure | John Carter |
+| | Cyber security | Pete Dingwall
+| | End user services | John Phillips |
+| | Operational services | Mario Gledhill |
+| | Digital strategy | Ant McCrea |
+**Outside Digital and Technology** | Customer Experience Digital and Data | Jemma Sheargold |
+| | Funding services | John Harris |
+| | Data services | Mick Rothwell |
 
 ## Help to find an architect
 

--- a/profession/architecture-profession.md
+++ b/profession/architecture-profession.md
@@ -38,7 +38,23 @@ They:
   - working with service delivery teams to align with architecture principles and standards
   - helping identify commonality across the organisation and finding the right solutions to business problems
 
-Contact the [architecture profession](mailto:architecture.profession@education.gov.uk) if you're not sure who your lead architect is.
+Use the table below to find out who your lead architect is. Or contact the [architecture profession](mailto:architecture.profession@education.gov.uk) if you're not sure.
+
+| **Business area** | **Portfolio/domain** | **Lead architect/s** |
+| - | - | - |
+**Digital and Technology** | Teaching Workforce | Andy Emley |
+| | Setting Leadership | tbc |
+| | Vulnerable Families and Children | Craig Jackson |
+| | School Business Professionals | Stewart Bailey-Smith, Atif Mir
+| | Internal Services/Digital Efficiencies | tbc |
+| | Platforms and Infrastructure | John Carter |
+| | Cyber Security | Pete Dingwall
+| | End User Services | John Phillips |
+| | Operational Services | Mario Gledhill |
+| | Digital Strategy | Ant McCrea |
+**Outside Digital and Technology** | CEDD (+ ESFA) | Jemma Sheargold |
+| | Funding Services | John Harris |
+| | Data | Mick Rothwell |
 
 ## Help to find an architect
 


### PR DESCRIPTION
Added tables to capability / profession page, plus a few tweaks, to describe the role of an architect and where lead architects are situated (to help other teams find them).